### PR TITLE
safari fix

### DIFF
--- a/_js/main.js
+++ b/_js/main.js
@@ -3,7 +3,7 @@ require("particles.js");
 import { animator, illustrator } from "./svgbuilder";
 
 document.addEventListener("DOMContentLoaded", () => {
-  let canvas = SVG("svg-container").size("530", "330px").viewbox(0, 0, 640, 480);
+  let canvas = SVG("svg-container").size("530", "330").viewbox(0, 0, 640, 480);
 
   particlesJS.load("particles-js", "./assets/particlesjs.json", () =>
     document.getElementById("particles-js").style.animation = "show 2s forwards");

--- a/_js/main.js
+++ b/_js/main.js
@@ -3,7 +3,7 @@ require("particles.js");
 import { animator, illustrator } from "./svgbuilder";
 
 document.addEventListener("DOMContentLoaded", () => {
-  let canvas = SVG("svg-container").size("90%", "90%").viewbox(0, 0, 640, 480);
+  let canvas = SVG("svg-container").size("530", "330px").viewbox(0, 0, 640, 480);
 
   particlesJS.load("particles-js", "./assets/particlesjs.json", () =>
     document.getElementById("particles-js").style.animation = "show 2s forwards");

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,11 +2,11 @@
 <html lang="en">
 {% include head.html %}
 <body>
+    <div id="particles-js"></div>
     <div id="site-container">
         {% include navigation.html %}
         {% include content.html %}
         {% include svg-container.html%}
     </div>
-    <div id="particles-js"></div>
 </body>
 </html>

--- a/_scss/_declarations.scss
+++ b/_scss/_declarations.scss
@@ -8,4 +8,4 @@ $inactive: #b4b4b4;
 $border-color: #28272a;
 
 $break-small: 425px;
-$break-large: 868px;
+$break-large: 1100px;

--- a/_scss/_style.scss
+++ b/_scss/_style.scss
@@ -8,6 +8,7 @@ html {
     #site-container {
       height: 100%;
       z-index: 2;
+      position: absolute;
       overflow-x: hidden;
       flex: 1;
       display: grid;
@@ -20,6 +21,10 @@ html {
       }
       #svg-container {
         width: 90%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
       }
 
       @media screen and (max-width: $break-large) and (min-width: 426px){

--- a/_scss/_style.scss
+++ b/_scss/_style.scss
@@ -53,8 +53,12 @@ html {
         #content {
           padding-top: 0;
           p {margin: 4% 0}
+          & > div {
+            padding-top: 0
+          }
         }
         #svg-container {
+          width: 100%;
           display: flex;
           justify-content: center;
         }


### PR DESCRIPTION
SVG size in now set in pixels (removing the size didnt help)
fixed z-index (navigation is now clickable)
changed the size of the largest breakpoint to accommodate the set sized SVG 